### PR TITLE
Use BUILD_ROOT to avoid any filesystem errors 

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -7,10 +7,12 @@ on:
         description: "Args to pass to make (ex. nano-package MEMO_TARGET=iphoneos-arm64-rootless MEMO_CFVER=1800)"
         required: true
 
+env:
+  BUILD_ROOT: "${{ github.workspace }}"
+
 jobs:
   run:
     runs-on: macos-12
-
     steps:
       - name: Checkout Procursus
         uses: actions/checkout@v3
@@ -26,8 +28,7 @@ jobs:
 
       - name: Run script
         run: |
-          ls
-          /opt/procursus/bin/make ${{ github.event.inputs.command }}
+          gmake ${{ github.event.inputs.command }} BUILD_ROOT="$BUILD_ROOT"
 
       - name: Get info
         id: information

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Run Procursus
+
 Run a make command in the Procursus repo and upload as an artifact.
 
 # How to use
@@ -8,3 +9,6 @@ Run a make command in the Procursus repo and upload as an artifact.
 3. Click Run Procursus on the left
 4. Click Run workflow, then put in the command
     - ex. `nano-package MEMO_TARGET=iphoneos-arm64-rootless MEMO_CFVER=1800`
+
+Note that some packages may not work, as the workflow will time out if no
+activity is being done.


### PR DESCRIPTION
This PR circumvents an error with the action, talking about the filesystem being read-only, by telling Procursus to use the current directory. This is meant to be done automatically, but maybe Procursus's `bash` doesn't work well with Github's runners.

On top of that, I've added a warning about the workflow timing out, which can occur if the runner is not doing anything after a while.